### PR TITLE
Fix broken react-compiler build

### DIFF
--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -43,7 +43,7 @@ export const getWebSideBabelPlugins = (
 
   const plugins = [
     // It is important that this plugin run first, as noted here: https://react.dev/learn/react-compiler
-    useReactCompiler && ['babel-plugin-react-compiler', { target: 19 }],
+    useReactCompiler && ['babel-plugin-react-compiler', { target: '19' }],
     // === Import path handling
     [
       'babel-plugin-module-resolver',


### PR DESCRIPTION
This fixes what broke via https://github.com/redwoodjs/redwood/pull/11822

As the docs also clearly show, this needs to be a string, not a Number. The error stack trace of #11934 literally says that.

Hence, resolves #11934

Needs to go into next patch release (v8.4.4 broke it) as well as v8.5.1.